### PR TITLE
Remove unused event-handler

### DIFF
--- a/addon/components/image-drop.js
+++ b/addon/components/image-drop.js
@@ -48,11 +48,6 @@ export default Ember.Component.extend({
     reader.readAsDataURL(file);
   },
 
-  noopHandler(event) {
-    event.stopPropagation();
-    event.preventDefault();
-  },
-
   drop(event) {
     event.preventDefault();
     if (event.dataTransfer.files && event.dataTransfer.files.length > 0) {


### PR DESCRIPTION
I assume that during cleanup in dd1d41a9646f293cde46e17372a0b1d291d2d857 `noopHandler` was forgotten to be removed.
