### PR TITLE
Added abort of handling a drop if file is null.

### DIFF
--- a/addon/components/image-drop.js
+++ b/addon/components/image-drop.js
@@ -37,6 +37,10 @@ export default Ember.Component.extend({
   }),
 
   handleFileDrop(file) {
+    if (file == null) {
+      return;
+    }
+
     this.set('file', file);
     var reader = new FileReader();
     reader.onload = (e) => {


### PR DESCRIPTION
An exception can occur if you click in the drop area to open the file dialog, select a file, then click cancel.

The result is that the `file` parameter to `handleFileDrop` becomes `undefined` in this case, and then gets passed to `readAsDataURL()`. The resultant error as seen in Chrome (OSX) is:

`Uncaught TypeError: Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'.`

The fix simply aborts if `file` is null-ish (null/undefined).
