### PR TITLE
clear <input> at end of 'change' handler

### DIFF
--- a/addon/components/image-drop.js
+++ b/addon/components/image-drop.js
@@ -33,8 +33,14 @@ export default Ember.Component.extend({
     const $input = this.$('input');
     $input.on('change', (event) => {
       this.handleFileDrop(event.target.files[0]);
+      this.resetInputElement($input);
     });
   }),
+
+  resetInputElement(inputElement) {
+    inputElement.wrap('<form>').closest('form').get(0).reset();
+    inputElement.unwrap();
+  },
 
   handleFileDrop(file) {
     if (file == null) {


### PR DESCRIPTION
This allows the user to upload the same image twice.  The use case could be if the image changed, but the file name didn't.  Or in our use-case, having a next / previous button that changed the context of the ember-image-drop.  Upon changing the context, the image would update, but trying to update the file via clicking to the same file didn't fire the input's 'change' event because it still held the last uploads values and so it wouldn't update the new contexts image.  

The down side is that the tooltip via the <input> will always say 'no file chosen', but it already has that behavior when using drag and drop.

Was only able to capture this in a webdriver io test, not sure how to accomplish an ember integration test showing this, but it is easy to replicate the issue by changing the contents of the file and trying to upload again.  The old image will remain because the file name is unchanged.
