### PR TITLE
Fix deprecation this._super is deprecated caused by old versi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "1.0.8"
+    "ember-cli-htmlbars": "1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "1.0.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
On the newest versions of ember-cli (2.6+)
<details>
 <summary>

"ember-cli-htmlbars": "0.7.9" throws deprecation</summary>



```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (/Users/d_dovgan/dev/Projects/TMS/TMSBLAdmin/src/node_modules/ember-cli/lib/models/addon.js:896:27)
```

</details>
